### PR TITLE
Redis: Update to 8.2.1

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -6,28 +6,40 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Petar Shtuchkin <petar.shtuchkin@redis.com> (@Peter-Sh)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
+Tags: 8.2.2-m01-int1, 8.2.2-m01-int1-bookworm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 8d4437bdd0443189f9b3ba5943fdf793f821e8e2
+GitFetch: refs/tags/v8.2.2-m01-int1
+Directory: debian
+
+Tags: 8.2.2-m01-int1-alpine, 8.2.2-m01-int1-alpine3.22
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 8d4437bdd0443189f9b3ba5943fdf793f821e8e2
+GitFetch: refs/tags/v8.2.2-m01-int1
+Directory: alpine
+
 Tags: 8.2.1, 8.2, 8, 8.2.1-bookworm, 8.2-bookworm, 8-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a13b78815d980881e57f15b9cf13cd2f26f3fab6
-GitFetch: refs/heads/release/8.2
+GitCommit: c692595f3bed5ac9ce85c6c32e17b68a7b100db0
+GitFetch: refs/tags/v8.2.1
 Directory: debian
 
 Tags: 8.2.1-alpine, 8.2-alpine, 8-alpine, 8.2.1-alpine3.22, 8.2-alpine3.22, 8-alpine3.22, alpine, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a13b78815d980881e57f15b9cf13cd2f26f3fab6
-GitFetch: refs/heads/release/8.2
+GitCommit: c692595f3bed5ac9ce85c6c32e17b68a7b100db0
+GitFetch: refs/tags/v8.2.1
 Directory: alpine
 
 Tags: 8.0.3, 8.0, 8.0.3-bookworm, 8.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 101262a8cf05b98137d88bc17e77db90c24cc783
-GitFetch: refs/heads/release/8.0
+GitFetch: refs/tags/v8.0.3
 Directory: debian
 
 Tags: 8.0.3-alpine, 8.0-alpine, 8.0.3-alpine3.21, 8.0-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 101262a8cf05b98137d88bc17e77db90c24cc783
-GitFetch: refs/heads/release/8.0
+GitFetch: refs/tags/v8.0.3
 Directory: alpine
 
 Tags: 7.4.5, 7.4, 7, 7.4.5-bookworm, 7.4-bookworm, 7-bookworm


### PR DESCRIPTION
THIS IS A DRAFT PR FOR AUTOMATION TESTING
PLEASE IGNORE IT AND SORRY FOR THE BOTHERING

Automated update for Redis 8.2.1

Release commit: a0ee0cb6c0105dc7ddd15c1db157528ba2d0a9cb
Release tag: v8.2.1
Compare: https://github.com/Peter-Sh/docker-library-redis/compare/v8.2.1^1...v8.2.1